### PR TITLE
#1 test - 견적 도메인의 Service 레이어 테스트 코드 추가

### DIFF
--- a/backend/src/main/java/com/programmers/pcquotation/domain/category/entity/Category.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/category/entity/Category.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Category {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateCreateRequest.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateCreateRequest.java
@@ -9,6 +9,5 @@ import lombok.Getter;
 @Getter
 public class EstimateCreateRequest {
 	private Integer estimateRequestId;
-	private Integer sellerId;
 	private List<EstimateItemDto> item;
 }

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateCreateRequest.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateCreateRequest.java
@@ -2,11 +2,13 @@ package com.programmers.pcquotation.domain.estimate.dto;
 
 import java.util.List;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+@AllArgsConstructor
 @Getter
 public class EstimateCreateRequest {
 	private Integer estimateRequestId;
-	private String sellerId;
+	private Integer sellerId;
 	private List<EstimateItemDto> item;
 }

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateItemDto.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateItemDto.java
@@ -1,8 +1,10 @@
 package com.programmers.pcquotation.domain.estimate.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class EstimateItemDto {
 	private Long item;      // "Intel i5-13500k"
 	private Integer price;    // 135000

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateUpdateReqDto.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/dto/EstimateUpdateReqDto.java
@@ -2,9 +2,11 @@ package com.programmers.pcquotation.domain.estimate.dto;
 
 import java.util.List;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class EstimateUpdateReqDto {
 	private Integer estimateId;
 	private List<EstimateItemDto> item;

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/entity/Estimate.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/entity/Estimate.java
@@ -16,15 +16,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Estimate {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/service/EstimateService.java
@@ -71,8 +71,6 @@ public class EstimateService {
 	public List<ReceivedQuoteDTO> getEstimateByRequest(Integer id) {
 		List<Estimate> list = estimateRepository.getAllByEstimateRequest_Id(id);
 
-		System.out.print(list.size());
-
 		return list.stream().map(quoto -> {
 			return ReceivedQuoteDTO.builder()
 				.id(quoto.getId())

--- a/backend/src/main/java/com/programmers/pcquotation/domain/estimate/service/EstimateService.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/estimate/service/EstimateService.java
@@ -90,9 +90,8 @@ public class EstimateService {
 
 		Seller seller = sellerService.findByUserName(username)
 			.orElseThrow(() -> new NoSuchElementException("존재하지 않는 판매자입니다."));
-		System.out.println(seller.getUsername());
+
 		List<Estimate> list = estimateRepository.getAllBySeller(seller);
-		System.out.println(list.size());
 
 		return list.stream().map(quoto -> {
 

--- a/backend/src/main/java/com/programmers/pcquotation/domain/item/entity/Item.java
+++ b/backend/src/main/java/com/programmers/pcquotation/domain/item/entity/Item.java
@@ -24,7 +24,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class Item {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -57,4 +57,3 @@ public class Item {
 		return item;
 	}
 }
-

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/controller/EstimateControllerTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/controller/EstimateControllerTest.java
@@ -40,7 +40,6 @@ class EstimateControllerTest {
 		String requestBody = """
 			{
 			   "estimateRequestId" : 1,
-			   "sellerId" : "seller123",
 			   "item" : [
 			     {
 			       "item" : 1,

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -167,4 +167,11 @@ public class EstimateServiceTest {
 
         assertEquals(1, estimateService.getEstimateBySeller("seller1").size());
     }
+
+    @Test
+    public void getEstimateBySeller_SellerNotFound() {
+        when(sellerService.findByUserName("seller1")).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class, () -> estimateService.getEstimateBySeller("seller1"));
+    }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -1,0 +1,113 @@
+package com.programmers.pcquotation.estimate.service;
+
+import com.programmers.pcquotation.domain.category.entity.Category;
+import com.programmers.pcquotation.domain.customer.entity.Customer;
+import com.programmers.pcquotation.domain.estimate.dto.EstimateCreateRequest;
+import com.programmers.pcquotation.domain.estimate.dto.EstimateItemDto;
+import com.programmers.pcquotation.domain.estimate.entity.Estimate;
+import com.programmers.pcquotation.domain.estimate.repository.EstimateRepository;
+import com.programmers.pcquotation.domain.estimate.service.EstimateService;
+import com.programmers.pcquotation.domain.estimaterequest.entity.EstimateRequest;
+import com.programmers.pcquotation.domain.estimaterequest.entity.EstimateRequestStatus;
+import com.programmers.pcquotation.domain.estimaterequest.service.EstimateRequestService;
+import com.programmers.pcquotation.domain.item.entity.Item;
+import com.programmers.pcquotation.domain.item.repository.ItemRepository;
+import com.programmers.pcquotation.domain.seller.entitiy.Seller;
+import com.programmers.pcquotation.domain.seller.service.SellerService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+public class EstimateServiceTest {
+    @Autowired
+    private EstimateService estimateService;
+
+    @MockitoBean
+    private EstimateRequestService estimateRequestService;
+
+    @MockitoBean
+    private SellerService sellerService;
+
+    @MockitoBean
+    private EstimateRepository estimateRepository;
+
+    @MockitoBean
+    private ItemRepository itemRepository;
+
+    private final EstimateRequest estimateRequest = new EstimateRequest(
+            1,
+            "게임용",
+            1_000_000,
+            "롤",
+            LocalDateTime.of(2025, 3, 4, 12, 0, 0),
+            mock(Customer.class),
+            List.of(),
+            EstimateRequestStatus.Wait
+    );
+
+    private final Seller sampleSeller = new Seller(
+            1L,
+            "seller1",
+            "1234",
+            "컴퓨터세상",
+            "seller1@test.com",
+            "좋아하는 음식은?",
+            "밥",
+            true,
+            "api-key"
+    );
+
+    private final Item sampleItem1 = new Item(
+            1L,
+            "CPU1",
+            "cpu1.png",
+            new Category(1L, "CPU"),
+            List.of()
+    );
+
+    private final Item sampleItem2 = new Item(
+            2L,
+            "RAM1",
+            "ram1.png",
+            new Category(2L, "RAM"),
+            List.of()
+    );
+
+    @Test
+    public void createEstimate_success() {
+        when(estimateRequestService.getEstimateRequestById(1)).thenReturn(Optional.of(estimateRequest));
+        when(sellerService.findByUserName("seller1")).thenReturn(Optional.of(sampleSeller));
+        when(itemRepository.findById(1L)).thenReturn(Optional.of(sampleItem1));
+        when(itemRepository.findById(2L)).thenReturn(Optional.of(sampleItem2));
+
+        EstimateCreateRequest request = new EstimateCreateRequest(
+                1,
+                1,
+                List.of(
+                        new EstimateItemDto(1L, 3000),
+                        new EstimateItemDto(2L, 5000)
+                )
+        );
+
+        estimateService.createEstimate(request, "seller1");
+
+        ArgumentCaptor<Estimate> estimateCaptor = ArgumentCaptor.forClass(Estimate.class);
+        verify(estimateRepository, times(1)).save(estimateCaptor.capture());
+
+        Estimate capturedEstimate = estimateCaptor.getValue();
+        assertNotNull(capturedEstimate);
+        assertEquals("seller1", capturedEstimate.getSeller().getUsername());
+        assertEquals(8000, capturedEstimate.getTotalPrice());
+    }
+}

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -22,10 +22,10 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @SpringBootTest
@@ -109,5 +109,21 @@ public class EstimateServiceTest {
         assertNotNull(capturedEstimate);
         assertEquals("seller1", capturedEstimate.getSeller().getUsername());
         assertEquals(8000, capturedEstimate.getTotalPrice());
+    }
+
+    @Test
+    public void createEstimate_estimateRequestNotFound() {
+        when(estimateRequestService.getEstimateRequestById(1)).thenReturn(Optional.empty());
+
+        EstimateCreateRequest request = new EstimateCreateRequest(
+                1,
+                1,
+                List.of(
+                        new EstimateItemDto(1L, 3000),
+                        new EstimateItemDto(2L, 5000)
+                )
+        );
+
+        assertThrows(NoSuchElementException.class, () -> estimateService.createEstimate(request, "seller1"));
     }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -105,7 +105,6 @@ public class EstimateServiceTest {
 
         EstimateCreateRequest request = new EstimateCreateRequest(
                 1,
-                1,
                 List.of(
                         new EstimateItemDto(1L, 3000),
                         new EstimateItemDto(2L, 5000)
@@ -129,7 +128,6 @@ public class EstimateServiceTest {
 
         EstimateCreateRequest request = new EstimateCreateRequest(
                 1,
-                1,
                 List.of(
                         new EstimateItemDto(1L, 3000),
                         new EstimateItemDto(2L, 5000)
@@ -144,7 +142,6 @@ public class EstimateServiceTest {
         when(sellerService.findByUserName("seller1")).thenReturn(Optional.empty());
 
         EstimateCreateRequest request = new EstimateCreateRequest(
-                1,
                 1,
                 List.of(
                         new EstimateItemDto(1L, 3000),

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -159,4 +159,12 @@ public class EstimateServiceTest {
 
         assertEquals(1, estimateService.getEstimateByRequest(1).size());
     }
+
+    @Test
+    public void getEstimateBySeller_Success() {
+        when(sellerService.findByUserName("seller1")).thenReturn(Optional.of(sampleSeller));
+        when(estimateRepository.getAllBySeller(sampleSeller)).thenReturn(List.of(sampleEstimate));
+
+        assertEquals(1, estimateService.getEstimateBySeller("seller1").size());
+    }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -184,4 +184,11 @@ public class EstimateServiceTest {
 
         verify(estimateRepository, times(1)).delete(sampleEstimate);
     }
+
+    @Test
+    public void deleteEstimate_estimateNotFound() {
+        when(estimateRepository.findById(1)).thenReturn(Optional.empty());
+
+        assertThrows(NoSuchElementException.class, () -> estimateService.deleteEstimate(1));
+    }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -126,4 +126,20 @@ public class EstimateServiceTest {
 
         assertThrows(NoSuchElementException.class, () -> estimateService.createEstimate(request, "seller1"));
     }
+
+    @Test
+    public void createEstimate_sellerNotFound() {
+        when(sellerService.findByUserName("seller1")).thenReturn(Optional.empty());
+
+        EstimateCreateRequest request = new EstimateCreateRequest(
+                1,
+                1,
+                List.of(
+                        new EstimateItemDto(1L, 3000),
+                        new EstimateItemDto(2L, 5000)
+                )
+        );
+
+        assertThrows(NoSuchElementException.class, () -> estimateService.createEstimate(request, "seller1"));
+    }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -4,6 +4,7 @@ import com.programmers.pcquotation.domain.category.entity.Category;
 import com.programmers.pcquotation.domain.customer.entity.Customer;
 import com.programmers.pcquotation.domain.estimate.dto.EstimateCreateRequest;
 import com.programmers.pcquotation.domain.estimate.dto.EstimateItemDto;
+import com.programmers.pcquotation.domain.estimate.dto.EstimateUpdateReqDto;
 import com.programmers.pcquotation.domain.estimate.entity.Estimate;
 import com.programmers.pcquotation.domain.estimate.repository.EstimateRepository;
 import com.programmers.pcquotation.domain.estimate.service.EstimateService;
@@ -190,5 +191,28 @@ public class EstimateServiceTest {
         when(estimateRepository.findById(1)).thenReturn(Optional.empty());
 
         assertThrows(NoSuchElementException.class, () -> estimateService.deleteEstimate(1));
+    }
+
+    @Test
+    public void updateEstimate_Success() {
+        when(estimateRepository.getEstimateById(1)).thenReturn(sampleEstimate);
+        when(itemRepository.findById(1L)).thenReturn(Optional.of(sampleItem1));
+
+        EstimateUpdateReqDto request = new EstimateUpdateReqDto(
+                1,
+                List.of(
+                        new EstimateItemDto(1L, 3000)
+                )
+        );
+
+        estimateService.updateEstimate(request);
+
+        ArgumentCaptor<Estimate> estimateCaptor = ArgumentCaptor.forClass(Estimate.class);
+        verify(estimateRepository, times(1)).save(estimateCaptor.capture());
+
+        Estimate capturedEstimate = estimateCaptor.getValue();
+        assertNotNull(capturedEstimate);
+        assertEquals("seller1", capturedEstimate.getSeller().getUsername());
+        assertEquals(3000, capturedEstimate.getTotalPrice());
     }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -89,7 +90,7 @@ public class EstimateServiceTest {
             estimateRequest,
             sampleSeller,
             5000,
-            List.of(),
+            new ArrayList<>(),
             LocalDateTime.of(2025, 3, 4, 12, 0),
             List.of()
     );
@@ -173,5 +174,14 @@ public class EstimateServiceTest {
         when(sellerService.findByUserName("seller1")).thenReturn(Optional.empty());
 
         assertThrows(NoSuchElementException.class, () -> estimateService.getEstimateBySeller("seller1"));
+    }
+
+    @Test
+    public void deleteEstimate_Success() {
+        when(estimateRepository.findById(1)).thenReturn(Optional.of(sampleEstimate));
+
+        estimateService.deleteEstimate(1);
+
+        verify(estimateRepository, times(1)).delete(sampleEstimate);
     }
 }

--- a/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
+++ b/backend/src/test/java/com/programmers/pcquotation/estimate/service/EstimateServiceTest.java
@@ -84,6 +84,16 @@ public class EstimateServiceTest {
             List.of()
     );
 
+    Estimate sampleEstimate = new Estimate(
+            1,
+            estimateRequest,
+            sampleSeller,
+            5000,
+            List.of(),
+            LocalDateTime.of(2025, 3, 4, 12, 0),
+            List.of()
+    );
+
     @Test
     public void createEstimate_success() {
         when(estimateRequestService.getEstimateRequestById(1)).thenReturn(Optional.of(estimateRequest));
@@ -141,5 +151,12 @@ public class EstimateServiceTest {
         );
 
         assertThrows(NoSuchElementException.class, () -> estimateService.createEstimate(request, "seller1"));
+    }
+
+    @Test
+    public void getEstimateByEstimateRequest_Success() {
+        when(estimateRepository.getAllByEstimateRequest_Id(1)).thenReturn(List.of(sampleEstimate));
+
+        assertEquals(1, estimateService.getEstimateByRequest(1).size());
     }
 }


### PR DESCRIPTION
## Issue
resolved #1

## 👩‍💻 요구 사항과 구현 내용
- 견적 도메인의 - Service 레이어의 테스트 코드 추가
  - 견적 생성
    - 성공
    - 존재하지 않는 견적 요청
    - 존재하지 않는 판매자 (실패)
  - 견적 조회
    - 견적 요청 id로 조회
    - 판매자 이름으로 조회
    - 존재하지 않는 판매자 (실패)
  - 견적 수정
  - 견적 삭제
    - 성공
    - 존재하지 않는 견적 (실패)

